### PR TITLE
Add views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,16 @@
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
     },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc="
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
@@ -167,6 +177,11 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+      "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
+    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -187,6 +202,11 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "async-each": {
       "version": "1.0.1",
@@ -303,6 +323,12 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "optional": true
     },
     "chai": {
       "version": "4.0.2",
@@ -518,8 +544,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "deep-eql": {
       "version": "2.0.2",
@@ -554,8 +579,7 @@
     "define-properties": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ="
     },
     "del": {
       "version": "2.2.2",
@@ -927,6 +951,18 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
       "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI="
     },
+    "express-handlebars": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-3.0.0.tgz",
+      "integrity": "sha1-gKBwu4GbCeSvLKbQeA91zgXnXC8=",
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI="
+        }
+      }
+    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
@@ -1049,8 +1085,7 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1755,8 +1790,7 @@
     "function-bind": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
-      "dev": true
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
     },
     "gaze": {
       "version": "0.5.2",
@@ -1984,8 +2018,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -2056,6 +2089,11 @@
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true
+    },
+    "handlebars": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08="
     },
     "har-schema": {
       "version": "1.0.5",
@@ -2224,8 +2262,7 @@
     "is-buffer": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-      "dev": true
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -2531,14 +2568,19 @@
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
     },
     "latest-version": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
       "integrity": "sha1-cs/Ebj6NG+ZR4eu1Tqn26pbzdLs=",
       "dev": true
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "optional": true
     },
     "lcid": {
       "version": "1.0.0",
@@ -2735,6 +2777,11 @@
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "lowercase-keys": {
       "version": "1.0.0",
@@ -2946,8 +2993,12 @@
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-      "dev": true
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+    },
+    "object.assign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
+      "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw="
     },
     "object.defaults": {
       "version": "1.1.0",
@@ -2996,6 +3047,18 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        }
+      }
     },
     "optionator": {
       "version": "0.8.2",
@@ -3309,6 +3372,11 @@
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
+    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -3471,8 +3539,7 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "1.1.3",
@@ -3537,6 +3604,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.2.0.tgz",
       "integrity": "sha1-sEY9f9PPWy/tZFAKtui4pJxbjmw="
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "optional": true
     },
     "rimraf": {
       "version": "2.6.1",
@@ -3659,6 +3732,11 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+    },
+    "source-map": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s="
     },
     "sparkles": {
       "version": "1.0.0",
@@ -3903,6 +3981,50 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "optional": true,
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "optional": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "optional": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "optional": true
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "optional": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "optional": true
+    },
     "umzug": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/umzug/-/umzug-1.12.0.tgz",
@@ -4072,6 +4194,12 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
       "dev": true
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "optional": true
     },
     "wkx": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "chai": "^4.0.2",
     "express": "^4.15.3",
+    "express-handlebars": "^3.0.0",
     "mocha": "^3.4.2",
     "pg": "^6.4.0",
     "pg-hstore": "^2.3.2",

--- a/src/controllers/home/getDbCheck.js
+++ b/src/controllers/home/getDbCheck.js
@@ -1,0 +1,9 @@
+const sequelize = require('../../models').sequelize;
+
+module.exports = (req, res) => {
+  sequelize.authenticate().then(() => {
+    res.send('Was able to connect to database');
+  }).catch(() => {
+    res.send('Was unable to connect to database');
+  });
+};

--- a/src/controllers/home/index.js
+++ b/src/controllers/home/index.js
@@ -1,0 +1,5 @@
+const express = require('express');
+
+const router = express.Router();
+
+module.exports = router;

--- a/src/controllers/home/index.js
+++ b/src/controllers/home/index.js
@@ -4,6 +4,7 @@ const router = express.Router();
 
 router.get('/', (req, res) => {
   res.render('home', {
+    pageTitle: 'Sessions',
     title: 'This is the home',
   });
 });

--- a/src/controllers/home/index.js
+++ b/src/controllers/home/index.js
@@ -1,5 +1,7 @@
 const express = require('express');
 
+const getDbCheck = require('./getDbCheck');
+
 const router = express.Router();
 
 router.get('/', (req, res) => {
@@ -8,5 +10,7 @@ router.get('/', (req, res) => {
     title: 'This is the home',
   });
 });
+
+router.get('/db-check', getDbCheck);
 
 module.exports = router;

--- a/src/controllers/home/index.js
+++ b/src/controllers/home/index.js
@@ -2,4 +2,10 @@ const express = require('express');
 
 const router = express.Router();
 
+router.get('/', (req, res) => {
+  res.render('home', {
+    title: 'This is the home',
+  });
+});
+
 module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -1,9 +1,13 @@
 const express = require('express');
 const sequelize = require('./models').sequelize;
 
+const homeRoute = require('./controllers/home');
+
 const app = express();
 
-app.get('/', (req, res) => {
+app.use('/', homeRoute);
+
+app.get('/db-check', (req, res) => {
   sequelize.authenticate().then(() => {
     res.send('Was able to connect to database');
   }).catch(() => {

--- a/src/server.js
+++ b/src/server.js
@@ -1,24 +1,19 @@
 const express = require('express');
 const exhbs = require('./views/exhbs');
 const path = require('path');
-const sequelize = require('./models').sequelize;
 
+// Route imports
 const homeRoute = require('./controllers/home');
 
+// Initializations
 const app = express();
 
+// Configuration
 app.engine('.hbs', exhbs.engine);
 app.set('view engine', '.hbs');
 app.set('views', path.join(__dirname, 'views'));
 
+// Router wiring
 app.use('/', homeRoute);
-
-app.get('/db-check', (req, res) => {
-  sequelize.authenticate().then(() => {
-    res.send('Was able to connect to database');
-  }).catch(() => {
-    res.send('Was unable to connect to database');
-  });
-});
 
 app.listen(process.env.PORT || 8080);

--- a/src/server.js
+++ b/src/server.js
@@ -1,9 +1,15 @@
 const express = require('express');
+const exhbs = require('./views/exhbs');
+const path = require('path');
 const sequelize = require('./models').sequelize;
 
 const homeRoute = require('./controllers/home');
 
 const app = express();
+
+app.engine('.hbs', exhbs.engine);
+app.set('view engine', '.hbs');
+app.set('views', path.join(__dirname, 'views'));
 
 app.use('/', homeRoute);
 

--- a/src/views/exhbs.js
+++ b/src/views/exhbs.js
@@ -1,0 +1,10 @@
+const expressHandlebars = require('express-handlebars');
+
+const exbhs = expressHandlebars.create({
+  defaultLayout: 'main',
+  layoutsDir: 'src/views/layouts',
+  partialsDir: 'src/views/partials',
+  extname: '.hbs',
+});
+
+module.exports = exbhs;

--- a/src/views/home.hbs
+++ b/src/views/home.hbs
@@ -1,0 +1,5 @@
+<h1>{{title}}</h1>
+
+<div>This is a test</div>
+
+<div>{{> ex}}</div>

--- a/src/views/layouts/main.hbs
+++ b/src/views/layouts/main.hbs
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8" />
-    <title>Static Title</title>
+    <title>{{pageTitle}}</title>
 </head>
 <body>
 

--- a/src/views/layouts/main.hbs
+++ b/src/views/layouts/main.hbs
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Static Title</title>
+</head>
+<body>
+
+    {{{body}}}
+
+</body>
+</html>

--- a/src/views/partials/ex.hbs
+++ b/src/views/partials/ex.hbs
@@ -1,0 +1,1 @@
+<p>This is an example partial</p>


### PR DESCRIPTION
For views, uses express-handlebars to integrate the handlebars template engine with express. 

Also makes use of express Routers to set up controllers. In node, when you `require` a folder, by default it will require the index.js in that folder. So we can make use of this behavior by creating an express router in the index.js for each controller, adding all of our routing methods to it, and then exporting it. To use it in our app, all that needs to be done is `require`ing the controller directory, and then using it like so:

```js
app.use('/', homeRoute);
```

Something to keep in mind with routes is that they have relative naming, so if you wanted to render the view for a controller named `sessions`, you would set it up like this:

```js
// sessions/index.js
router.get('/', (req, res) => res.send('This is a session'));
module.exports = router;

// server.js
const sessionsRouter = require('./controllers/sessions');
app.use('/sessions', sessionsRouter);
```

Then when you GET `/sessions`, you'll receive the expected 'This is a session' string. You can also nest routers in the same way.

Also, other functions in the same controller don't always need to be broken out into separate files, I just did as an example. A good rule of thumb is that if they need a bunch of their own state or imports that aren't require for other routes, or are just complex then its probably best to extract it into its own route file. I like the naming convention of `<httpMethod><routeName>`.js (getDbCheck.js), whenever possible.


The handlebars stuff was thankfully pretty easy to set up, once I found the right example. Good resources:
* [The docs on the homepage](http://handlebarsjs.com/)
* [The README](https://github.com/ericf/express-handlebars)
* [This example](https://github.com/ericf/express-handlebars/tree/master/examples/advanced)