### PR TITLE
Add model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ WORKDIR /code
 
 RUN yarn run build
 
-CMD ["yarn","start"]
+CMD ["sh", "./scripts/server.sh"]

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -11,4 +11,4 @@ WORKDIR /code
 
 EXPOSE 8080 8082
 
-CMD ["yarn","run","dev"]
+CMD ["sh", "./scripts/server.sh"]

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "./node_modules/.bin/eslint .",
     "start": "node ./src/server.js",
     "build": "./node_modules/.bin/webpack",
+    "migrate": "cd src && ../node_modules/.bin/sequelize db:migrate",
     "dev": "./node_modules/.bin/npm-run-all --parallel dev-server dev-client",
     "dev-server": "./node_modules/.bin/nodemon ./src/server.js",
     "dev-client": "./node_modules/.bin/webpack-dev-server --host 0.0.0.0"
@@ -29,6 +30,7 @@
     "react-dom": "^15.6.1",
     "request": "^2.81.0",
     "sequelize": "^4.2.0",
+    "sequelize-cli": "^2.7.0",
     "serve-static": "^1.12.3",
     "webpack": "^3.0.0"
   },
@@ -43,7 +45,6 @@
     "mocha": "^3.4.2",
     "nodemon": "^1.11.0",
     "npm-run-all": "^4.0.2",
-    "sequelize-cli": "^2.7.0",
     "webpack-dev-server": "^2.5.0"
   }
 }

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -1,0 +1,19 @@
+#/bin/bash
+
+n=0
+until [ $n -ge 5 ]
+do
+   yarn run migrate && break
+   n=$[$n+1]
+   sleep 2
+done
+
+if [ $n -eq 5 ]; then
+  exit 1
+fi
+
+if [ "$NODE_ENV" = "production" ]; then
+  yarn start
+else
+  yarn run dev
+fi

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -4,10 +4,12 @@
     "password": "password",
     "database": "sessions_app",
     "host": "db",
-    "dialect": "postgres"
+    "dialect": "postgres",
+    "logging": false
   },
   "production": {
     "use_env_variable": "DATABASE_URL",
-    "dialect": "postgres"
+    "dialect": "postgres",
+    "logging": false
   }
 }

--- a/src/examples/userCRUD.js
+++ b/src/examples/userCRUD.js
@@ -1,0 +1,34 @@
+const User = require('../models').User;
+
+const queryMatt = () => (
+  User.findOne({
+    where: {
+      username: {
+        $like: 'matt%',
+      },
+    },
+  })
+);
+
+const log = (operation, matt) => console.log(`${operation} User: ${JSON.stringify(matt)}\n`);
+
+queryMatt()
+  .then((matt) => {
+    log('BEFORE CREATE', matt);
+
+    return User.create({ username: 'matt' }).then(queryMatt);
+  })
+  .then((matt) => {
+    log('AFTER CREATE', matt);
+
+    return User.update({ username: 'matthew' }, { where: { username: 'matt' } }).then(queryMatt);
+  })
+  .then((matt) => {
+    log('AFTER UPDATE', matt);
+    return User.destroy({ where: { username: 'matthew' } }).then(queryMatt);
+  })
+  .then((matt) => {
+    log('AFTER DESTROY', matt);
+
+    return 'Done';
+  });

--- a/src/migrations/20170708021310-create-user.js
+++ b/src/migrations/20170708021310-create-user.js
@@ -1,0 +1,32 @@
+'use strict';
+module.exports = {
+  up: function(queryInterface, Sequelize) {
+    return queryInterface.createTable('Users', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      username: {
+        allowNull: false,
+        type: Sequelize.STRING
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      deletedAt: {
+        allowNull: true,
+        type: Sequelize.DATE
+      },
+    });
+  },
+  down: function(queryInterface, Sequelize) {
+    return queryInterface.dropTable('Users');
+  }
+};

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,0 +1,18 @@
+'use strict';
+module.exports = function(sequelize, DataTypes) {
+  var User = sequelize.define('User', {
+    username: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  }, {
+    timestamps: true,
+    paranoid: true,
+    classMethods: {
+      associate: function(models) {
+        // associations can be defined here
+      }
+    }
+  });
+  return User;
+};


### PR DESCRIPTION
[Trello](https://trello.com/c/RbVD2M6G/27-set-up-one-model-user-skeleton)

Adds a the User model with just one attribute, `username`, and its associated `id`. The User table also has some metadata like 

* `createdAt`
* `updatedAt`
* `deletedAt`

`deletedAt` is for the `paranoid` option on the User model, which allows you to soft-delete users. All you have to do is set `deletedAt`, and Sequelize will automatically construct queries that exclude rows that have `deletedAt` set. This makes undeleting Users easy, as you can just unset the `deletedAt` field.

You can see some basic CRUD operations in action by running the example script. Just fire up the server, and then start a shell in the container (`./scripts/web-shell.sh`). Once you're in, just run `node ./src/examples/userCRUD.js`.

Also adds a script for starting the server, instead of just running `yarn run dev/start`. We also want to run `yarn run migrate` beforehand. There's some retry logic in there in case `sequelize-cli` can't connect at first.