### PR TITLE
Fix spot auth

### DIFF
--- a/src/server/controllers/auth/config.js
+++ b/src/server/controllers/auth/config.js
@@ -37,7 +37,7 @@ passport.use(new SpotifyStrategy({
     return { id: dataValues.id, payload };
   })
   .then(user => db.User.update(
-    { payload: JSON.stringify(user.payload) },
+    { payload: user.payload },
     { where: { id: user.id } }))
   .catch(err => done(err))));
 

--- a/src/server/migrations/20170711050459-add-user-payload.js
+++ b/src/server/migrations/20170711050459-add-user-payload.js
@@ -3,7 +3,7 @@
 module.exports = {
   up: function (queryInterface, Sequelize) {
     return queryInterface.addColumn('Users', 'payload', {
-      type: Sequelize.STRING,
+      type: Sequelize.JSON,
       allowNull: true,
     });
   },

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -5,6 +5,10 @@ module.exports = function(sequelize, DataTypes) {
       type: DataTypes.STRING,
       allowNull: false,
     },
+    payload: {
+      type: DataTypes.JSON,
+      allowNull: true,
+    },
   }, {
     timestamps: true,
     paranoid: true,


### PR DESCRIPTION
I wasn't able to sleep so I checked out your branch again! The issue seems to have been that while the column 'payload' was being added to the Users table, the User model didn't have the attribute 'payload'. Since Postgres supports storing JSON objects, I think it would be better for us to store the payload as that type, rather than as a String. I wanted to add a migration to change the type of payload, but I received an error that you can't automatically cast a String into a JSON object. So, I ended up just directly modifying the migration itself. 😨 I recognize that this definitely isn't best practice, but since we don't have any data in our database it's okay to do a reset at this stage. 

Here are screenshots showing me printing 'user.payload' and the corresponding result. Removed that print when I pushed.
<img width="438" alt="screen shot 2017-07-12 at 2 43 12 am" src="https://user-images.githubusercontent.com/21322741/28112522-2d45abac-66ae-11e7-8e68-0f730b4dcf20.png">
<img width="719" alt="screen shot 2017-07-12 at 2 43 27 am" src="https://user-images.githubusercontent.com/21322741/28112527-315940c8-66ae-11e7-943e-2ffa44847222.png"> 