### PR TITLE
Make Spotify Wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Sessions server and client",
   "main": "app.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha --reporter spec",
+    "test": "./node_modules/.bin/mocha --reporter spec --recursive test",
     "lint": "./node_modules/.bin/eslint --ext 'js,jsx' src test config",
     "start": "node ./src/server/server.js",
     "build": "./node_modules/.bin/webpack",
@@ -67,6 +67,8 @@
     "mocha": "^3.4.2",
     "nodemon": "^1.11.0",
     "npm-run-all": "^4.0.2",
+    "proxyquire": "^1.8.0",
+    "sinon": "^2.3.8",
     "webpack-dev-server": "^2.5.0"
   }
 }

--- a/src/server/controllers/auth/spotify/index.js
+++ b/src/server/controllers/auth/spotify/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { passport, authMiddleware } = require('../setup');
+const spotifyRequest = require('../../../helpers/spotifyRequest');
 
 const router = express.Router();
 
@@ -13,7 +14,9 @@ router.get('/callback',
   });
 
 router.get('/test', authMiddleware, (req, res) => {
-  res.send(req.user);
+  spotifyRequest(req.user, 'get', '/me')
+    .then(resp => res.send(resp.data))
+    .catch(() => res.status(500).end());
 });
 
 module.exports = router;

--- a/src/server/controllers/sessions/index.js
+++ b/src/server/controllers/sessions/index.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const { authMiddleware } = require('../auth/setup');
-const axios = require('axios');
-const qs = require('querystring');
+const spotifyRequest = require('../../helpers/spotifyRequest');
 
 const router = express.Router();
 
@@ -9,22 +8,21 @@ router.get('/', authMiddleware, (req, res) => {
   res.render('sessions');
 });
 
-router.post('/search-tracks', authMiddleware, (req, res) => {
-  const query = {
+router.post('/search-tracks', authMiddleware, (req, res) =>
+  spotifyRequest(req.user, 'get', '/search', {
     q: `track:${req.body.query}`,
     type: 'track',
-  };
-  axios({
-    method: 'get',
-    url: `https://api.spotify.com/v1/search?${qs.encode(query)}`,
-    headers: { Authorization: `Bearer ${req.user.payload.accessToken}` },
   })
-  .then(resp => res.send(resp.data.tracks.items.map(track => ({
-    name: track.name,
-    id: track.id,
-    artist: track.artists[0].name,
-  }))))
-  .catch(() => res.send([]));
-});
+  .then((resp) => {
+    const { items } = resp.data.tracks;
+    const searchResults = items.map(track => ({
+      name: track.name,
+      id: track.id,
+      artist: track.artists[0].name,
+    }));
+
+    res.send(searchResults);
+  })
+  .catch(() => res.send([])));
 
 module.exports = router;

--- a/src/server/helpers/spotifyRequest.js
+++ b/src/server/helpers/spotifyRequest.js
@@ -1,0 +1,58 @@
+const axios = require('axios');
+const qs = require('querystring');
+
+const db = require('../models');
+
+const apiBaseRoute = 'https://api.spotify.com/v1';
+const authBaseRoute = 'https://accounts.spotify.com';
+const basicAuth = new Buffer(`${process.env.SPOTIFY_CLIENT_ID}:${process.env.SPOTIFY_CLIENT_SECRET}`).toString('base64');
+
+const makeRequestParams = (user, method, endpoint, query) => ({
+  method,
+  url: `${apiBaseRoute}${endpoint}`,
+  params: query,
+  headers: { Authorization: `Bearer ${user.payload.accessToken}` },
+});
+
+const refresh = (user, method, endpoint, query) =>
+  axios({
+    method: 'post',
+    url: `${authBaseRoute}/api/token`,
+    headers: {
+      Authorization: `Basic ${basicAuth}`,
+    },
+    data: qs.stringify({
+      grant_type: 'refresh_token',
+      refresh_token: user.payload.refreshToken,
+    }),
+  })
+  .then((newTokens) => {
+    const { payload } = user;
+    payload.accessToken = newTokens.data.access_token;
+
+    if (newTokens.data.refresh_token) {
+      payload.refreshToken = newTokens.data.refresh_token;
+    }
+
+    db.User.update({ payload }, { where: { id: user.id } });
+
+    return user;
+  })
+  .then(newUser => axios(makeRequestParams(newUser, method, endpoint, query)))
+  .catch((err) => { throw err; });
+
+/**
+ * Makes a request to the spotify API on behalf of the user
+ * @param {Object} user     - The user's session object (req.user)
+ * @param {String} method   - The HTTP method to use for the request (lowercase)
+ * @param {String} endpoint - The endpoint of Spotify's API to hit (after /v1) ex: /me
+ * @param {Object} query    - Query parameters to be encoded format: {key: value}
+ */
+module.exports = (user, method, endpoint, query) =>
+  axios(makeRequestParams(user, method, endpoint, query))
+    .catch((err) => {
+      if (err.response.status === 401) {
+        return refresh(user, method, endpoint, query);
+      }
+      throw err;
+    });

--- a/src/server/helpers/spotifyRequest.js
+++ b/src/server/helpers/spotifyRequest.js
@@ -18,9 +18,7 @@ const refresh = (user, method, endpoint, query) =>
   axios({
     method: 'post',
     url: `${authBaseRoute}/api/token`,
-    headers: {
-      Authorization: `Basic ${basicAuth}`,
-    },
+    headers: { Authorization: `Basic ${basicAuth}` },
     data: qs.stringify({
       grant_type: 'refresh_token',
       refresh_token: user.payload.refreshToken,

--- a/test/server/helpers/spotifyWrapper.spec.js
+++ b/test/server/helpers/spotifyWrapper.spec.js
@@ -1,0 +1,111 @@
+const expect = require('chai').expect;
+const proxyquire = require('proxyquire').noCallThru();
+const sinon = require('sinon');
+const Promise = require('bluebird');
+const qs = require('querystring');
+
+let spotifyWrapper;
+let axiosMock;
+let dbMock;
+let user;
+
+process.env.SPOTIFY_CLIENT_ID = 'SPOTIFY_CLIENT_ID';
+process.env.SPOTIFY_CLIENT_SECRET = 'SPOTIFY_CLIENT_SECRET';
+const basicAuth = new Buffer(`${process.env.SPOTIFY_CLIENT_ID}:${process.env.SPOTIFY_CLIENT_SECRET}`).toString('base64');
+
+const init = (authorized, refresh) => {
+  axiosMock = sinon.stub();
+
+  if (authorized) {
+    axiosMock.returns(Promise.resolve('response'));
+  } else {
+    axiosMock.onCall(0).returns(Promise.reject({
+      response: {
+        status: 401,
+      },
+    }));
+
+    if (refresh) {
+      axiosMock.onCall(1).returns(Promise.resolve({
+        data: {
+          access_token: 'new access token',
+        },
+      }));
+
+      axiosMock.onCall(2).returns(Promise.resolve('response'));
+    }
+  }
+
+  dbMock = {
+    User: {
+      update: sinon.stub().returns(Promise.resolve()),
+    },
+  };
+
+  spotifyWrapper = proxyquire('../../../src/server/helpers/spotifyRequest', {
+    axios: axiosMock,
+    '../models': dbMock,
+  });
+
+  user = {
+    id: 0,
+    payload: {
+      accessToken: 'access token',
+      refreshToken: 'refresh token',
+    },
+  };
+};
+
+describe('Spotify Wrapper tests', () => {
+  describe('success', () => {
+    beforeEach(() => init(true));
+
+    it('completes without throwing an error', () =>
+      spotifyWrapper(user, 'method', '/endpoint', {})
+        .then(() => sinon.assert.pass())
+        .catch(() => sinon.assert.fail()));
+
+    it('makes the request with the proper parameters', () =>
+      spotifyWrapper(user, 'method', '/endpoint', {})
+        .then(() => sinon.assert.calledWith(axiosMock, {
+          method: 'method',
+          url: 'https://api.spotify.com/v1/endpoint',
+          params: {},
+          headers: { Authorization: 'Bearer access token' },
+        })));
+
+    it('returns the response to the user', () =>
+      spotifyWrapper(user, 'method', '/endpoint', {})
+        .then(res => expect(res).to.equal('response')));
+  });
+
+  describe('unauthorized but successfully refreshed', () => {
+    beforeEach(() => init(false, true));
+
+    it('completes without throwing an error', () =>
+      spotifyWrapper(user, 'method', '/endpoint', {})
+        .then(() => sinon.assert.pass())
+        .catch(() => sinon.assert.fail()));
+
+    it('makes the refresh request with the proper parameters', () =>
+      spotifyWrapper(user, 'method', '/endpoint', {})
+        .then(() => sinon.assert.calledWith(axiosMock, {
+          method: 'post',
+          url: 'https://accounts.spotify.com/api/token',
+          headers: { Authorization: `Basic ${basicAuth}` },
+          data: qs.stringify({
+            grant_type: 'refresh_token',
+            refresh_token: 'refresh token',
+          }),
+        })));
+
+    it('saves the new token in the user model', () =>
+      spotifyWrapper(user, 'method', '/endpoint', {})
+        .then(() => sinon.assert.calledWith(dbMock.User.update, {
+          payload: {
+            accessToken: 'new access token',
+            refreshToken: 'refresh token',
+          },
+        }, { where: { id: 0 } })));
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1676,7 +1676,7 @@ detect-node@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.3.tgz#a2033c09cc8e158d37748fbde7507832bd6ce127"
 
-diff@3.2.0:
+diff@3.2.0, diff@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
@@ -2304,6 +2304,13 @@ filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
 
+fill-keys@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fill-keys/-/fill-keys-1.0.2.tgz#9a8fa36f4e8ad634e3bf6b4f3c8882551452eb20"
+  dependencies:
+    is-object "~1.0.1"
+    merge-descriptors "~1.0.0"
+
 fill-range@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
@@ -2432,6 +2439,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formatio@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
+  dependencies:
+    samsam "1.x"
 
 forwarded@~0.1.0:
   version "0.1.0"
@@ -2956,13 +2969,9 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
-iconv-lite@0.4.15:
+iconv-lite@0.4.15, iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
-
-iconv-lite@~0.4.13:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
@@ -3202,6 +3211,10 @@ is-number@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
   dependencies:
     kind-of "^3.0.2"
+
+is-object@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -3726,6 +3739,10 @@ lodash@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551"
 
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -3835,7 +3852,7 @@ meow@^3.3.0, meow@^3.7.0:
     redent "^1.0.0"
     trim-newlines "^1.0.0"
 
-merge-descriptors@1.0.1:
+merge-descriptors@1.0.1, merge-descriptors@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
@@ -3950,6 +3967,10 @@ mocha@^3.4.2:
     mkdirp "0.5.1"
     supports-color "3.1.2"
 
+module-not-found-error@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
+
 moment-timezone@^0.5.4:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.13.tgz#99ce5c7d827262eb0f1f702044177f60745d7b90"
@@ -3996,6 +4017,10 @@ mute-stream@0.0.5:
 nan@^2.3.0, nan@^2.3.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 natives@^1.1.0:
   version "1.1.0"
@@ -4510,6 +4535,12 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -4968,6 +4999,14 @@ proxy-addr@~1.1.4:
   dependencies:
     forwarded "~0.1.0"
     ipaddr.js "1.3.0"
+
+proxyquire@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-1.8.0.tgz#02d514a5bed986f04cbb2093af16741535f79edc"
+  dependencies:
+    fill-keys "^1.0.2"
+    module-not-found-error "^1.0.0"
+    resolve "~1.1.7"
 
 prr@~0.0.0:
   version "0.0.0"
@@ -5434,6 +5473,10 @@ resolve@^1.0.0, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0, resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.5"
 
+resolve@~1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
 restore-cursor@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
@@ -5481,6 +5524,10 @@ rx-lite@^3.1.2:
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
 
 sass-graph@^2.1.1:
   version "2.2.4"
@@ -5702,6 +5749,19 @@ sigmund@^1.0.1, sigmund@~1.0.0:
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon@^2.3.8:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.3.8.tgz#31de06fed8fba3a671e576dd96d0a5863796f25c"
+  dependencies:
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^1.6.0"
+    native-promise-only "^0.8.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -6059,6 +6119,10 @@ terraformer@~1.0.5:
   resolved "https://registry.yarnpkg.com/terraformer/-/terraformer-1.0.8.tgz#51e0ad89746fcf2161dc6f65aa70e42377c8b593"
   dependencies:
     "@types/geojson" "^1.0.0"
+
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
 text-table@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Makes a Spotify API caller wrapper method. Will automatically refresh a user's access token and update it in the db if they get a 401. Also changed /auth/spotify/test to return the value of hitting the /me route in Spotify. Try out different Spotify API methods with query params too!